### PR TITLE
feat : fix timeline, add pos_filter and link

### DIFF
--- a/DTS/load_dataset.py
+++ b/DTS/load_dataset.py
@@ -74,6 +74,7 @@ class DTSDataset(Dataset):
 
     def __len__(self):
         return len(self.dataset)
+
     def __getitem__(self, idx):
         # print('neg_input_ids' , self.dataset[idx][1]['input_ids'].squeeze(0))
         return {'input_ids' : self.dataset[idx]['input_ids'].squeeze(0),
@@ -82,6 +83,7 @@ class DTSDataset(Dataset):
         # return {'input_ids' : [self.dataset[idx][0]['input_ids'].squeeze(0),self.dataset[idx][1]['input_ids'].squeeze(0)],
         #          'attention_mask' : [self.dataset[idx][0]['attention_mask'].squeeze(0),self.dataset[idx][1]['attention_mask'].squeeze(0)],
         #          'label' : torch.tensor(self.label[idx])}
+
     def _preprocessing(self,df):
         df["id_boolean"] = df["User"].apply(self.id_check)                   # 방장봇이 대화하면 제거
         df["Message"] = df["Message"].apply(self.text_replace)               # \n, 링크 전처리 작업
@@ -90,7 +92,7 @@ class DTSDataset(Dataset):
         df.reset_index(drop=True,inplace = True)
         df['Message2'] = pd.concat([df['Message'].iloc[1:],pd.Series('None')]).reset_index(drop=True)           # window 작업
         df['Date'] = pd.to_datetime(df['Date'],infer_datetime_format=True)                                  # date 날짜화 str -> datetime
-        df = df[["Date", "User", "Message","Message2"]]
+        df = df[["index", "Date", "User", "Message", "Message2"]]
         # df_filtered2 = df[ df['Date'].isin(pd.date_range('2022-12-16', '2022-12-17',freq = 's'))] # 원하는 일자별로 자를 수도 있음묘 
         return df
 
@@ -98,6 +100,7 @@ class DTSDataset(Dataset):
         if my_id == "방장봇":
             return False
         return True
+
     def text_processing(self,dialog):                                    # Text 전처리 작업
         find_text = re.findall('[ㄱ-ㅎㅏ-ㅣ]+', dialog)
         vowel = "".join(find_text)
@@ -117,6 +120,7 @@ class DTSDataset(Dataset):
         
 
         return True
+        
     def text_replace(self,dialog):                                       # '\n' -> ' ' , 링크 -> [LINK] 로 변경
         line = "\n"
         dialog = re.sub(pattern=line, repl =" ", string=dialog)

--- a/app/app.py
+++ b/app/app.py
@@ -57,6 +57,7 @@ def form_return(uploaded_file, start_date, time_period):
     else:
         encoder_type = chardet.detect(uploaded_file.getvalue().splitlines()[0])['encoding']
         df = txt_to_csv(uploaded_file, encoding=encoder_type)
+    df = df.reset_index()
     sample = get_now(start_date,time_period, df)   # data 크기 감소
     return sample
 
@@ -71,13 +72,13 @@ def load_models():
     return cs_model, bert_model, cfg
 
 if __name__ == '__main__':
-    st.title("Open Talk Demo")
+    st.title("오픈 채팅방 요약 서비스")
     with st.form(key='my_form'):
         c1,c2 = st.columns(2)
-        with c1 : start_date = st.date_input('this start from...')
-        with c2 : time_period  = st.slider('Max day you can check is 10 days', 1,10)
-        uploaded_file = st.file_uploader('upload your OpenTalk csv or txt',type = ['csv', 'txt'])
-        submit = st.form_submit_button(label='Submit') # True or False
+        with c1 : start_date = st.date_input('대화 시작 시점을 설정해주세요.')
+        with c2 : time_period  = st.slider('총 기간을 설정해주세요. 최대 10일입니다.', 1,10)
+        uploaded_file = st.file_uploader('CSV 또는 TXT 파일을 제출해주세요.',type = ['csv', 'txt'])
+        submit = st.form_submit_button(label='제출') # True or False
     # items = []
     if submit:
         cs_model, bert_model, cfg = load_models()
@@ -85,15 +86,15 @@ if __name__ == '__main__':
         tokenizer = AutoTokenizer.from_pretrained('klue/bert-base')
         sample = form_return(uploaded_file, start_date, time_period)
         if len(sample) <100:
-            st.warning('Too Small data to summary... please update time_period and start_date')
-        with st.spinner('get_DTS..'): # with 아래 까지 실행되는 동안 동그라미를 띄운다.
+            st.warning('데이터가 충분하지 않습니다. 대화 시점과 기간을 확인해주세요.')
+        with st.spinner('DTS 추론 중..'): # with 아래 까지 실행되는 동안 동그라미를 띄운다.
             # api로 날릴수 있는 부분 -> backend에 요청할 부분!
-            items = get_DTS(bert_model=bert_model,cs_model=cs_model,tokenizer=tokenizer,inputs = sample) #pandas
-            st.success('Done...') #질문!
-            if 'items' not in st.session_state: 
+            items = get_DTS(bert_model=bert_model, cs_model=cs_model, tokenizer=tokenizer, inputs = sample) #pandas
+            st.success('...완료') #질문!
+            # if 'items' not in st.session_state:
                 # dict key value -> 선언을 하게 되면 로컬변수가 아니라 캐시로 저장을 하게 됩니다.
                 # with문 안에서 선언되는 것들 또는 함수 안에서 진행되는 변수들을 전역 변수로 바꿔 준다고 이해
-                st.session_state['items'] = items
+            st.session_state['items'] = items
     cls = st.columns([0.27,0.03,0.7],gap ='small') # 화면 분할 레이어 3개로 
     with cls[2]:
         timeline = None # 지역변수니까!
@@ -103,21 +104,25 @@ if __name__ == '__main__':
         # else:
         #     st.warning("items not available")
         if timeline is not None:
-            with st.spinner('get_summary..'):
+            with st.spinner('요약 생성 중..'):
                 sums = predict_summary(inputs = timeline) #전체를 하는게 아니라 하나만!
-                tab1, tab2 = st.tabs(["Summary_output", "Viz"])
-                summary = tab1.text_area('summary Output',f'''
+                tab1, tab2 = st.tabs(["요약 결과", "검색 링크"])
+                summary = tab1.text_area('기다려주셔서 감사합니다.',f'''
+'{timeline['content']}'에 관한 {timeline['start'][:-3]}부터 {timeline['due'][:-3]}까지의 채팅 요약입니다.
+
 {sums}
 
-YEOMbora에서는 당신의 채팅방을 더욱 원활하게 활용될 수 있도록 노력하고 있습니다. 
+
+YOUMbora는 당신의 채팅방이 더욱 원활하게 활용될 수 있도록 노력하고 있습니다. 
             '''
             ,height = 300)
-                tab1.download_button('Download summary text', summary)
-                tab2.title('시각화 대상') # 시각화 추가 
-                tab2.download_button('Dows', summary)
+                tab1.download_button('요약문 다운로드', summary)
+                tab2.markdown(f"[키워드 검색 링크](http://google.com/search?q={timeline['content']})")
+                tab2.markdown(f"[요약 검색 링크](http://google.com/search?q={sums.replace(' ','')})")
+                # tab2.download_button('Dows', summary)
             with cls[0]:
                 # TODO : html로 구현 시 bar를 넣어서 위아래로 확인할 수 있도록
-                with st.expander("대화보기 -> 궁금하냐? ㅋ"):
+                with st.expander("원문 대화 보기"):
                     for idx, item in enumerate(timeline['dialogue'][:7]):
                         message(item, key = f"<uniquevalueofsomesort{idx}>")
 # TODO : REQUEST

--- a/app/prediction.py
+++ b/app/prediction.py
@@ -62,11 +62,10 @@ def keyword_extractor(dialogue):
     # nltk로 명사군의 단어들만 뽑아보기
     try:
         word_tokenize('Hello nltk')
-        print('nltk requirement fulfilled')
     except:
-        import nltk
-        nltk.download('averaged_preceptron_tagger')
-        print('nltk averaged_preceptron_tagger downloaded')
+        # import nltk
+        # nltk.download('averaged_perceptron_tagger')
+        print('nltk averaged_perceptron_tagger downloaded')
     to_keywords = [i for i,p in pos_tag(word_tokenize(' '.join(dialogue))) \
                                                     if len(i)>1 and p[:2]=='NN' and i !='..']
     keyword, freq = collections.Counter(to_keywords).most_common(1)[0]


### PR DESCRIPTION
1. 타임 라인 갱신 안되는 오류를 해결하였습니다.
2. 키워드 추출에 명사 필터링을 추가하였습니다.
3. 결과 창을 다듬고 검색 링크를 추가하였습니다.

## Description
1. app.py의 if 'items' not in st.session_state: 부분을 주석 처리하여 해결하였습니다.
2. prediction.py에 nltk의 pos_tag, word_tokenize를 임포트하여 해결하였습니다.
   - 설치해야 할 모듈이 따로 있어 예외처리로 넣었습니다.
3. 키워드와 기간을 활용해 요약 결과를 다듬고 시각화는 링크로 대체하였습니다.
   - 현재 링크로 넣어놨지만 검색 창이 실제로 뜨는 것을 상상했습니다. 
   - 경우에 따라 검색 페이지로 페이지를 넘기는 것도 가능할 것 같습니다.
4. 추가로 한글화 패치를 적용하였습니다.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
#26 
<!-- If your PR refers to a related issue, link it here. -->
